### PR TITLE
Fix SuperFX2 Core Speed (#852)

### DIFF
--- a/source/snes9x/fxemu.cpp
+++ b/source/snes9x/fxemu.cpp
@@ -148,7 +148,9 @@ void S9xSuperFXExec (void)
 {
 	if ((Memory.FillRAM[0x3000 + GSU_SFR] & FLG_G) && (Memory.FillRAM[0x3000 + GSU_SCMR] & 0x18) == 0x18)
 	{
-		FxEmulate(((Memory.FillRAM[0x3000 + GSU_CLSR] & 1) ? (SuperFX.speedPerLine * 8 / 3) : SuperFX.speedPerLine) * Settings.SuperFXClockMultiplier / 100);
+		#ifdef GEKKO
+		FxEmulate(((Memory.FillRAM[0x3000 + GSU_CLSR] & 1) ? (SuperFX.speedPerLine * Timings.SuperFX2CoreSpeed) : SuperFX.speedPerLine) * Settings.SuperFXClockMultiplier / 100);
+		#endif
 
 		uint16 GSUStatus = Memory.FillRAM[0x3000 + GSU_SFR] | (Memory.FillRAM[0x3000 + GSU_SFR + 1] << 8);
 		if ((GSUStatus & (FLG_G | FLG_IRQ)) == FLG_IRQ)

--- a/source/snes9x/memmap.cpp
+++ b/source/snes9x/memmap.cpp
@@ -3723,7 +3723,16 @@ void CMemory::ApplyROMFixes (void)
 	Timings.HDMAStart   = SNES_HDMA_START_HC + Settings.HDMATimingHack - 100;
 	Timings.HBlankStart = SNES_HBLANK_START_HC + Timings.HDMAStart - SNES_HDMA_START_HC;
 	Timings.IRQTriggerCycles = 14;
-
+	
+	#ifdef GEKKO
+	if (match_id("YI  ")) { // Super Mario World 2 - Yoshi's Island 
+			Timings.SuperFX2CoreSpeed = 8 / 3;
+		}
+		else {
+			Timings.SuperFX2CoreSpeed = 5 / 2;
+		}
+	#endif
+	
 	if (!Settings.DisableGameSpecificHacks)
 	{
 		// The delay to sync CPU and DMA which Snes9x cannot emulate.

--- a/source/snes9x/snes9x.h
+++ b/source/snes9x/snes9x.h
@@ -181,6 +181,9 @@ struct STimings
 	int32	IRQFlagChanging;	// This value is just a hack.
 	int32	APUSpeedup;
 	bool8	APUAllowTimeOverflow;
+#ifdef GEKKO
+	int32	SuperFX2CoreSpeed;		// Make the SuperFX2 Core Speed adjustable
+#endif
 };
 
 struct SSettings


### PR DESCRIPTION
Commit "Snes9x - SFX: Make SFX2 1/3 faster than 1.59.2." fixes the SuperFX2 speed for Yoshi's Island but it broke the speed for other SuperFX2 games.

This hack will correct that.