### PR TITLE
Snes9x - Add explicit declaration of tile unit templates.

### DIFF
--- a/source/snes9x/tile.cpp
+++ b/source/snes9x/tile.cpp
@@ -297,6 +297,38 @@ void S9xInitTileRenderer (void)
 }
 
 // Functions to select which converter and renderer to use.
+extern template struct TileImpl::Renderers<DrawTile16, Normal1x1>;
+extern template struct TileImpl::Renderers<DrawClippedTile16, Normal1x1>;
+extern template struct TileImpl::Renderers<DrawMosaicPixel16, Normal1x1>;
+extern template struct TileImpl::Renderers<DrawBackdrop16, Normal1x1>;
+extern template struct TileImpl::Renderers<DrawMode7MosaicBG1, Normal1x1>;
+extern template struct TileImpl::Renderers<DrawMode7BG1, Normal1x1>;
+extern template struct TileImpl::Renderers<DrawMode7MosaicBG2, Normal1x1>;
+extern template struct TileImpl::Renderers<DrawMode7BG2, Normal1x1>;
+
+extern template struct TileImpl::Renderers<DrawTile16, Normal2x1>;
+extern template struct TileImpl::Renderers<DrawClippedTile16, Normal2x1>;
+extern template struct TileImpl::Renderers<DrawMosaicPixel16, Normal2x1>;
+extern template struct TileImpl::Renderers<DrawBackdrop16, Normal2x1>;
+extern template struct TileImpl::Renderers<DrawMode7MosaicBG1, Normal2x1>;
+extern template struct TileImpl::Renderers<DrawMode7BG1, Normal2x1>;
+extern template struct TileImpl::Renderers<DrawMode7MosaicBG2, Normal2x1>;
+extern template struct TileImpl::Renderers<DrawMode7BG2, Normal2x1>;
+extern template struct TileImpl::Renderers<DrawTile16, Interlace>;
+extern template struct TileImpl::Renderers<DrawClippedTile16, Interlace>;
+extern template struct TileImpl::Renderers<DrawMosaicPixel16, Interlace>;
+
+extern template struct TileImpl::Renderers<DrawTile16, Hires>;
+extern template struct TileImpl::Renderers<DrawClippedTile16, Hires>;
+extern template struct TileImpl::Renderers<DrawMosaicPixel16, Hires>;
+extern template struct TileImpl::Renderers<DrawBackdrop16, Hires>;
+extern template struct TileImpl::Renderers<DrawMode7MosaicBG1, Hires>;
+extern template struct TileImpl::Renderers<DrawMode7BG1, Hires>;
+extern template struct TileImpl::Renderers<DrawMode7MosaicBG2, Hires>;
+extern template struct TileImpl::Renderers<DrawMode7BG2, Hires>;
+extern template struct TileImpl::Renderers<DrawTile16, HiresInterlace>;
+extern template struct TileImpl::Renderers<DrawClippedTile16, HiresInterlace>;
+extern template struct TileImpl::Renderers<DrawMosaicPixel16, HiresInterlace>;
 
 void S9xSelectTileRenderers (int BGMode, bool8 sub, bool8 obj)
 {

--- a/source/snes9x/tileimpl.h
+++ b/source/snes9x/tileimpl.h
@@ -793,7 +793,6 @@ namespace TileImpl {
 	template<class PIXEL>
 	struct DrawMode7MosaicBG2 : public DrawTileMosaic<PIXEL, DrawMode7BG2_OP> {};
 
-
 	#undef DRAW_PIXEL
 
 } // namespace TileImpl


### PR DESCRIPTION
Silences warnings and prevents double-compilation.